### PR TITLE
Resolve "in modbuild we need to source libpbuild before parsing the arguments"

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -24,6 +24,9 @@ source libstd.bash    || {
         echo "Oops: library '$_' cannot be loaded!" 1>&2; exit 3;
 }
 
+source libpbuild.bash    || \
+        std::die 3 "Oops: Cannot source library -- '$_'"
+
 # save arguments, (still) required for building dependencies
 declare -r ARGS="$@"
 
@@ -376,9 +379,6 @@ else
 fi
 source "${build_config}" || \
         std::die 3 "Oops: Cannot source configuration file -- '${build_config}'"
-source libpbuild.bash    || \
-        std::die 3 "Oops: Cannot source library -- '$_'"
-
 
 declare -r BUILD_SCRIPT
 declare -r BUILDBLOCK_DIR


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "in modbuild we need to source l...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/14) |
> | **GitLab MR Number** | [14](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/14) |
> | **Date Originally Opened** | Mon, 27 May 2019 |
> | **Date Originally Merged** | Mon, 27 May 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #43