### PR TITLE
Resolve "modbuild: rmdir on macOS doesn't support --ignore-fail-on-non-empty option"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -943,7 +943,7 @@ pbuild::make_all() {
                                 "removing release file '${release_file}' ..."
 			[[ "${dry_run}" == 'no' ]] && rm -v "${release_file}"
 		fi
-		rmdir -p --ignore-fail-on-non-empty "${dstdir}" 2>/dev/null
+		rmdir -p "${dstdir}" 2>/dev/null || :
 	}
 
 	########################################################################


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modbuild: rmdir on macOS doesn'...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/36) |
> | **GitLab MR Number** | [36](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/36) |
> | **Date Originally Opened** | Wed, 4 Sep 2019 |
> | **Date Originally Merged** | Wed, 4 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #71