### PR TITLE
Resolve "modbuild: typo in definition of pbuild::supported_compilers"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -186,7 +186,7 @@ pbuild::supported_os() {
 #   $@: supported compiler (like GCC, Intel, PGI).
 #       Default is all.
 #
-pbuild::supported_compiler() {
+pbuild::supported_compilers() {
 	SUPPORTED_COMPILERS+=( "$@" )
 }
 #......................................................................


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modbuild: typo in definition of...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/41) |
> | **GitLab MR Number** | [41](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/41) |
> | **Date Originally Opened** | Thu, 19 Sep 2019 |
> | **Date Originally Merged** | Thu, 19 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #77