### PR TITLE
Resolve "modbuild: allow '.*' as version argument"

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -248,7 +248,7 @@ parse_args() {
 		-* )
 			std::die 1 "Invalid option -- '$1'"
 			;;
-		[=0-9]* )
+		[=0-9]* | '.*' )
 			versions+=( "$1" )
 			;;
 		'')	


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modbuild: allow '.*' as version...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/42) |
> | **GitLab MR Number** | [42](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/42) |
> | **Date Originally Opened** | Thu, 19 Sep 2019 |
> | **Date Originally Merged** | Thu, 19 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #78