### PR TITLE
Resolve "modulecmd: missing newline in the warning after loading a unstable or deprecated module"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -526,13 +526,13 @@ subcommand_load() {
                                        "${current_modulefile}"
                 fi
 
-		local msg=$(printf "%s %s: %s -- %s\n" \
+		local msg=$(printf "%s %s: %s -- %s" \
                                   "${CMD}" 'load' \
                                   "${release} module has been loaded" \
                                   "${m}")
 		if [[ ${verbosity_lvl} != silent ]] && \
                            [[ ${release} != stable ]]; then
-			std::info "${msg}"
+		        std::info "%s\n" "${msg}"
 		fi
 		logger "${msg}"
 	done


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: missing newline in t...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/49) |
> | **GitLab MR Number** | [49](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/49) |
> | **Date Originally Opened** | Fri, 27 Sep 2019 |
> | **Date Originally Merged** | Fri, 27 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #85