### PR TITLE
Resolve "use modbuild.in in Pmodules build script"

### DIFF
--- a/build
+++ b/build
@@ -276,7 +276,7 @@ pmodules::compile() {
 		local -r version=$(get_version "${name}")
 		shift
 
-		"${BOOTSTRAP_DIR}/Pmodules/modbuild" \
+		"${BOOTSTRAP_DIR}/Pmodules/modbuild.in" \
 			"--config=${config_file}" \
 			"--enable-cleanup" \
 			"--force-rebuild" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "use modbuild.in in Pmodules bui...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/69) |
> | **GitLab MR Number** | [69](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/69) |
> | **Date Originally Opened** | Thu, 17 Dec 2020 |
> | **Date Originally Merged** | Thu, 17 Dec 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #100