### PR TITLE
Resolve "module function should not be used in libpbuild"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -1430,7 +1430,7 @@ pbuild.build_module() {
 			fi
 
 			std::info "Loading module: ${m}\n"
-			module load "${m}"
+			eval $( "${MODULECMD}" bash load "${m}" )
 		done
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "module function should not be u...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/70) |
> | **GitLab MR Number** | [70](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/70) |
> | **Date Originally Opened** | Thu, 25 Feb 2021 |
> | **Date Originally Merged** | Thu, 25 Feb 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #102