### PR TITLE
modulecmd: save environment after unloading a module

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -642,6 +642,7 @@ subcommand_unload() {
 		PMODULES_HOME=${saved_home}
 		export_env 'PMODULES_HOME'
 	fi
+	g_env_must_be_saved='yes'
 }
 
 ##############################################################################


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [modulecmd: save environment after unload...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/82) |
> | **GitLab MR Number** | [82](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/82) |
> | **Date Originally Opened** | Thu, 6 May 2021 |
> | **Date Originally Merged** | Thu, 6 May 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

(cherry picked from commit 9a0d55ed85b3ce769eef0315dc82dd74d63a8fa0)