### PR TITLE
Resolve "terse output in sub-cmd avail is broken"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -882,7 +882,7 @@ subcommand_avail() {
 	terse_output() {
 		output_header "$1"
 		local -i i=0
-		for i in ${!mods[@]}; do
+		for (( i=0; i<${#mods[@]}; i+=3 )); do
 			local mod=${mods[i]}
 			local rel_stage=${mods[i+1]}
 			case ${rel_stage} in


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "terse output in sub-cmd avail i...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/96) |
> | **GitLab MR Number** | [96](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/96) |
> | **Date Originally Opened** | Mon, 7 Jun 2021 |
> | **Date Originally Merged** | Mon, 7 Jun 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #128