### PR TITLE
Resolve "modulecmd: use some defaults if Pmodules.conf does not exist"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -2326,12 +2326,6 @@ if [[ -n ${PMODULES_ENV} ]]; then
 		fi
 		g_env_must_be_saved='yes'
 	fi
-	if [[ -v DefaultGroups ]] || [[ -v DefaultReleaseStages ]] || [[ -v ReleaseStages ]]; then
-		source "${pmodules_config_file}" || \
-			std::die 3 "Oops: cannot parse config file  -- %s\n" \
-				 "${pmodules_config_file}"
-
-	fi
 else
 	pmodules_init
 fi


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: use some defaults if...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/98) |
> | **GitLab MR Number** | [98](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/98) |
> | **Date Originally Opened** | Wed, 9 Jun 2021 |
> | **Date Originally Merged** | Wed, 9 Jun 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #129