### PR TITLE
Resolve "fix output of group name in avail sub-commanf"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1042,8 +1042,12 @@ subcommand_avail() {
         local string
 	for string in "${pattern[@]}"; do
 		for dir in "${modulepath[@]}"; do
-			local group="${dir/${PMODULES_ROOT}\/}"
-			group="${group%%/*}"
+			if [[ ${dir} =~ ${PMODULES_ROOT} ]]; then
+				local group="${dir/${PMODULES_ROOT}\/}"
+				group="${group%%/*}"
+			else
+				local group="${dir}"
+			fi
 			if (( ${#opt_groups[@]} > 0 )) && [[ ! -v opt_groups[${group}] ]]; then
 				continue
 			fi


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "fix output of group name in ava...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/104) |
> | **GitLab MR Number** | [104](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/104) |
> | **Date Originally Opened** | Fri, 17 Sep 2021 |
> | **Date Originally Merged** | Fri, 17 Sep 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #135