### PR TITLE
fixes in module search sub-command

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1771,7 +1771,7 @@ subcommand_search() {
                 print_modulefiles() {
 			fmt=''
 			func_print_header='print_header_none'
-                        func_print_line='print_header_none'
+                        func_print_line='print_line_modulefile'
                 }
 
                 print_header_none() {
@@ -1779,16 +1779,7 @@ subcommand_search() {
                 }
 
                 print_line_modulefile() {
-                        local line=( "$@" )
-			# group first
-			local out="${line[2]}/"
-			# add directory of modulefiles
-			out+="${PMODULES_MODULEFILES_DIR}/"
-			for d in "${line[@]:3}"; do
-				out+="$d/"
-			done
-			out+="${line[0]}"
-			std::info "${out}"
+			std::info "$4"
                 }
 
                 print_line_csv() {
@@ -1952,10 +1943,26 @@ subcommand_search() {
 			-a | --all-releases )
 				opt_use_rel_stages+="${ReleaseStages}"
 				;;
-			--src )
-				# :FIXME: do we have to add some sanity checks here?
-				src_prefix=$2
-				shift
+			--src | --src=*)
+                                if [[ "$1" == --src ]]; then
+                                        local src_prefix="$2"
+                                        shift
+                                else
+                                        local src_prefix="${1/--src=}"
+                                fi
+				if [[ ! -e "${src_prefix}" ]]; then
+					std::die 1 "%s %s: %s -- %s" \
+						 "${CMD}" 'search' \
+                                                 "illegal value for --src option" \
+                                                 "${src_prefix} does not exist"
+				fi
+				if [[ ! -d "${src_prefix}" ]]; then
+					std::die 1 "%s %s: %s -- %s" \
+						 "${CMD}" 'search' \
+                                                 "illegal value for --src option" \
+                                                 "${src_prefix} is not a directory"
+				fi
+				src_prefix=$(std::get_abspath "${src_prefix}")
 				;;
                         -v | --verbose )
                                 opt_print_verbose='yes'


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [fixes in module search sub-command](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/106) |
> | **GitLab MR Number** | [106](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/106) |
> | **Date Originally Opened** | Thu, 28 Oct 2021 |
> | **Date Originally Merged** | Thu, 28 Oct 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- error fixed in printing the modulefile
- sanity checks added if --src is specified


(cherry picked from commit c22422aca93d11d0addd9beae31995305d56f6ac)