### PR TITLE
Resolve "unsetting aliases in sub-command 'purge' is broken"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1489,7 +1489,7 @@ subcommand_purge() {
 		# re-run with right shell
                 "${modulecmd}" "${Shell}" 'purge'
         fi
-	eval "${output}"
+	eval "$(echo "${output}"|sed -e 's/;unalias [^;]*//g')"
 	if [[ -n "${error}" ]]; then
                 echo "${error}" 1>&2
 	fi


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "unsetting aliases in sub-comman...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/130) |
> | **GitLab MR Number** | [130](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/130) |
> | **Date Originally Opened** | Tue, 5 Apr 2022 |
> | **Date Originally Merged** | Tue, 5 Apr 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #158