### PR TITLE
Resolve "modulecmd: sub-cmd whatis and keyword are broken"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -2859,6 +2859,9 @@ case ${subcommand} in
 	rm )
 		subcommand='unload'
 		;;
+	find )
+		subcommand='search'
+		;;
 	switch )
 		subcommand='swap'
 		;;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: sub-cmd whatis and k...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/141) |
> | **GitLab MR Number** | [141](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/141) |
> | **Date Originally Opened** | Wed, 27 Jul 2022 |
> | **Date Originally Merged** | Thu, 28 Jul 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #168