### PR TITLE
Resolve "modbuild read from stdin if no variants files are found"

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -297,6 +297,9 @@ find_variants_files(){
                         || [[ -e "${f}.$(uname -s)" ]] \
                         || files+=( "$f" )
 	done
+	if (( ${#files[@]} == 0 )); then
+		std::die 2 "No suitable variants file found!"
+	fi
         (( nullglob_set == 1 )) && shopt -u nullglob
 	std::upvar "$1" "${files[@]}"
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modbuild read from stdin if no ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/145) |
> | **GitLab MR Number** | [145](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/145) |
> | **Date Originally Opened** | Thu, 3 Nov 2022 |
> | **Date Originally Merged** | Thu, 3 Nov 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #172