### PR TITLE
Merge branch '186-prefix-lib64-is-missing-in-ld_library_path' into 'master'

### DIFF
--- a/Pmodules/libmodules.tcl
+++ b/Pmodules/libmodules.tcl
@@ -150,7 +150,6 @@ proc _pmodules_setenv { PREFIX name version } {
 	set setenv_dirs  [dict create \
 			      "${PREFIX}/include"		"${NAME}_INCLUDE_DIR" \
 			      "${PREFIX}/lib"			"${NAME}_LIBRARY_DIR" \
-			      "${PREFIX}/lib64"			"${NAME}_LIBRARY_DIR" \
 			    ]
 	set prepend_dirs [dict create \
 			      "${PREFIX}/bin"			{ "PATH" } \
@@ -158,6 +157,7 @@ proc _pmodules_setenv { PREFIX name version } {
 			      "${PREFIX}/share/man"		{ "MANPATH" } \
 			      "${PREFIX}/include"		{ "C_INCLUDE_PATH" "CPLUS_INCLUDE_PATH" } \
 			      "${PREFIX}/lib"			{ "LIBRARY_PATH" "LD_LIBRARY_PATH"} \
+			      "${PREFIX}/lib64"			{ "LIBRARY_PATH" "LD_LIBRARY_PATH"} \
 			      "${PREFIX}/lib/pkgconfig"		{ "PKG_CONFIG_PATH" } \
 			      "${PREFIX}/share/pkgconfig"	{ "PKG_CONFIG_PATH" } \
 			      "${PREFIX}/lib/cmake"		{ "CMAKE_MODULE_PATH" } \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '186-prefix-lib64-is-missin...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/161) |
> | **GitLab MR Number** | [161](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/161) |
> | **Date Originally Opened** | Mon, 6 Feb 2023 |
> | **Date Originally Merged** | Mon, 6 Feb 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "$PREFIX/lib64 is missing in LD_LIBRARY_PATH"

Closes #186

See merge request Pmodules/src!159

(cherry picked from commit 52cfb4e744cfe4196ab74a79a5646bd25383cd7f)

ec50e224 bugfix in setting LD_LIBRARY_PATH