### PR TITLE
Merge branch '198-dont-setenv-is-broken' into 'master'

### DIFF
--- a/Pmodules/libmodules.tcl
+++ b/Pmodules/libmodules.tcl
@@ -172,16 +172,19 @@ proc _pmodules_setenv { PREFIX name version } {
 		setenv $key $value
 	}
 	dict for {key value} $setenv_dirs {
-		if { [lsearch ${::dont-setenv} $key] >= 0 || ![file isdirectory $key] } {
+		if { [lsearch ${::dont-setenv} $value] >= 0 || ![file isdirectory $key] } {
 			continue
 		}
 		setenv $value $key
 	}
 	dict for {key value} $prepend_dirs {
-		if { [lsearch ${::dont-setenv} $key] >= 0 || ![file isdirectory $key] } {
+		if { ![file isdirectory $key] } {
 			continue
 		}
 		foreach var $value {
+			if { [lsearch ${::dont-setenv} $var] >= 0 } {
+				continue
+			}
 			prepend-path $var $key
 		}
 	}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '198-dont-setenv-is-broken'...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/175) |
> | **GitLab MR Number** | [175](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/175) |
> | **Date Originally Opened** | Fri, 21 Apr 2023 |
> | **Date Originally Merged** | Fri, 21 Apr 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "dont-setenv is broken"

Closes #198

See merge request Pmodules/src!174

(cherry picked from commit 21004e09ff4669b6c18cbf4e549034e5f07790c6)

68ac0bc2 libmodules.tcl: dont setenv issue fixed