### PR TITLE
Resolve "output of module(-file) is missing in error message of sub-cmd unload if module doesn't exist any more"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -855,7 +855,7 @@ subcommand_unload() {
 			continue
 		fi
 		local interp
-		is_modulefile interp "${lmfile}" || die_not_a_modulefile "${m}"
+		is_modulefile interp "${lmfile}" || die_not_a_modulefile "${lmfile}"
 		if [[ "${interp}" == 'lmod' ]]; then
 			current_modulefile="${current_modulefile/${moduledir}\/}"
 			modulecmd="${lmod_cmd}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "output of module(-file) is miss...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/192) |
> | **GitLab MR Number** | [192](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/192) |
> | **Date Originally Opened** | Mon, 3 Jul 2023 |
> | **Date Originally Merged** | Mon, 3 Jul 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #215