### PR TITLE
build-system: substitute env variables if used in configure args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.1.19
 ### modulecmd
 * arguments to CMake and autotools can now be defined in the
-  YAML configuration file. (issue #249)
+  YAML configuration file. (issue #249, #253)
 * Required patches can now be defined in the YAML configuration
   file (issue #249)
 * BUGFIX: parsing the version number and setting the variables
@@ -19,7 +19,7 @@
   exist. (issue #247)
 * The number of directory components to be removed while
   un-taring can now be configured in the YAML configuration
-  file. If not specified, 1 is used as default. (issue #251)
+  file. If not specified, 1 is used as default. (issue #252)
 
 ## Version 1.1.18
 ### modulecmd

--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -20,7 +20,7 @@ declare -a SOURCE_SHA256_SUMS=()
 declare -a SOURCE_NAMES=()
 declare -a SOURCE_STRIP_DIRS=() 
 declare -A SOURCE_UNPACK_DIRS=()
-declare -a CONFIGURE_ARGS=()
+declare -ax CONFIGURE_ARGS=()
 declare -a PATCH_FILES=()
 declare -a PATCH_STRIPS=()
 declare -a PATCH_STRIP_DEFAULT='1'
@@ -779,12 +779,17 @@ pbuild::configure() {
 			fi
 			;;
 	esac
+	local -a config_args=()
+	local -- arg=''
+	for arg in "${CONFIGURE_ARGS[@]}"; do
+		config_args+=( $(envsubst <<<"${arg}") )
+	done
 	if [[ -r "${SRC_DIR}/configure" ]] && \
 		   [[ "${configure_with}" == 'auto' ]] || \
 			   [[ "${configure_with}" == 'autotools' ]]; then
 		${SRC_DIR}/configure \
 			  --prefix="${PREFIX}" \
-			  "${CONFIGURE_ARGS[@]}" || \
+			  "${config_args[@]}" || \
 			std::die 3 \
 				 "%s " "${module_name}/${module_version}:" \
 				 "configure failed"
@@ -794,7 +799,7 @@ pbuild::configure() {
 		# note: in most/many cases a cmake module is used!
 		cmake \
 			-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-			"${CONFIGURE_ARGS[@]}" \
+			"${config_args[@]}" \
 			"${SRC_DIR}" || \
 			std::die 3 \
 				 "%s " "${module_name}/${module_version}:" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [build-system: substitute env variables i...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/230) |
> | **GitLab MR Number** | [230](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/230) |
> | **Date Originally Opened** | Tue, 16 Apr 2024 |
> | **Date Originally Merged** | Tue, 16 Apr 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #253