### PR TITLE
Resolve "modulecmd: bug in sub-cmd unuse if argument is a directory"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1864,7 +1864,7 @@ subcommand_unuse() {
                 if is_release_stage "${arg}"; then
                         # argument is release stage
 			std::remove_path UsedReleaseStages "${arg}"
-                        return
+                        return 0
                 fi
 		if [[ -v OverlayInfo[${arg}:type] ]]; then
 			unuse_overlay "${arg}"
@@ -1873,10 +1873,11 @@ subcommand_unuse() {
 		if [[ -d ${arg} ]]; then
 			local dir=$(std::get_abspath "${arg}")
 			std::remove_path MODULEPATH "${dir}"
+			return 0
 		fi
                 if [[ -n ${GroupDepths[${arg}]} ]]; then
                         unuse_group "${arg}"
-                        return
+                        return 0
                 fi
 
 		std::die 3 "%s %s: %s -- %s" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: bug in sub-cmd unuse...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/239) |
> | **GitLab MR Number** | [239](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/239) |
> | **Date Originally Opened** | Thu, 2 May 2024 |
> | **Date Originally Merged** | Thu, 2 May 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #262