### PR TITLE
Resolve "build-system: option --overlay is only allowed with legacy config files"

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -145,10 +145,12 @@ MISCELLANEOUS OPTIONS:
 --tmpdir
         Directory used for building a module.
 
---overlay
-        Install in this overlay. Defaults to '${PMODULES_HOME%%/Tools*}'.
 --legacy
-        Use legacy configuration files.
+        Use legacy configuration files. 
+
+--overlay
+        Install in this overlay. Defaults to the base overlay. This
+	option can only be used with legacy configuration file.
 
 DOCUMENTATION:
 	Full documentation is available at 
@@ -397,6 +399,9 @@ parse_args() {
 				 "%s -- %s" \
 				 "YAML config file doesn't exist or is not readable" \
 				 "${yaml_config_file}"
+		[[ "${opt_overlay}" == 'yes' ]] && \
+			std::die 2 \
+				 "opt '--overlay' can only be used together with legacy config files!"
 		std::info "Using YAML configuration file - ${yaml_config_file}"
 	fi
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: option --overlay ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/244) |
> | **GitLab MR Number** | [244](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/244) |
> | **Date Originally Opened** | Thu, 2 May 2024 |
> | **Date Originally Merged** | Thu, 2 May 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #267