### PR TITLE
Resolve "build-system: libpbuild isn't used any more"

### DIFF
--- a/build
+++ b/build
@@ -26,7 +26,6 @@ declare -r BOOTSTRAP_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 declare -r SRC_DIR="${BOOTSTRAP_DIR}/Pmodules"
 
 source "${SRC_DIR}/libstd.bash"		|| { echo "Oops!" 1>&2; exit 42; }
-source "${SRC_DIR}/libpbuild.bash"	|| { echo "Oops!" 1>&2; exit 42; }
 
 declare -r  PMOD_DIR="Tools/Pmodules/${VERSION}"
 # config directory and file relative to install root


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: libpbuild isn't u...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/248) |
> | **GitLab MR Number** | [248](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/248) |
> | **Date Originally Opened** | Fri, 24 May 2024 |
> | **Date Originally Merged** | Fri, 24 May 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #271