### PR TITLE
Resolve "modulecmd: fix use of unset variables"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -35,7 +35,7 @@ std::def_cmds "${path}" \
 	      'rm' 'rmdir' 'sed' 'sort' 'tput' 'yq'
 
 declare -rx TCL_LIBRARY="${PMODULES_HOME}/lib/tcl@TCL_VERSION@"
-declare -x  TCLLIBPATH
+declare -x  TCLLIBPATH=${TCLLIBPATH:-''}
 std::prepend_path TCLLIBPATH "${PMODULES_HOME}/lib/Pmodules"
 
 declare -r tcl_cmd="${libexecdir}/modulecmd.bin"
@@ -804,7 +804,7 @@ subcommand_load() {
 		else
 			modulecmd="${tcl_cmd}"
 		fi
-		local output=$("${modulecmd}" 'bash' ${opts} 'load' \
+		local output=$("${modulecmd}" 'bash' "${opts[@]}" 'load' \
                                               "${current_modulefile}" 2> "${tmpfile}")
 
                 # we do not want to print the error message we got from
@@ -826,7 +826,7 @@ subcommand_load() {
                         echo "${output}"
                 else
 			# re-run with right shell
-                        "${modulecmd}" "${Shell}" ${opts} 'load' \
+                        "${modulecmd}" "${Shell}" "${opts[@]}" 'load' \
                                        "${current_modulefile}"
                 fi
 		eval "${output}"
@@ -2626,7 +2626,7 @@ subcommand_search() {
 		esac
 		shift
 	done
-	if [[ -z "${src_prefix}" ]]; then
+	if (( ${#src_prefix[@]} == 0 )); then
 		local ol=''
 		for ol in "${UsedOverlays[@]}"; do
 			src_prefix+=( "${OverlayInfo[${ol}:mod_root]}" )


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: fix use of unset var...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/260) |
> | **GitLab MR Number** | [260](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/260) |
> | **Date Originally Opened** | Fri, 12 Jul 2024 |
> | **Date Originally Merged** | Fri, 12 Jul 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #282