### PR TITLE
Resolve "modulecmd: don't show modulepath of modules not in the Pmodules hierarchy"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -2104,8 +2104,8 @@ subcommand_list() {
 
 	human_readable_output(){
 		# get list of loaded modules with stripped MODULEPATH
-		IFS=':' read -r -a modules <<< "${LOADEDMODULES}"
-
+		IFS=':' read -r -a modules \
+		   < <( ${sed} "s;${MODULEPATH//:/\/\\\|}/;;g" <<< "${_LMFILES_}" )
 		local strs=()
 		local -i n=1
 		local -i colsize=0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: don't show modulepat...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/263) |
> | **GitLab MR Number** | [263](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/263) |
> | **Date Originally Opened** | Fri, 12 Jul 2024 |
> | **Date Originally Merged** | Fri, 12 Jul 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #285