### PR TITLE
Resolve "modulecmd: print help if modulecmd is called without arg"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -3507,6 +3507,7 @@ subcommand_initclear() {
 # parse arguments
 #
 
+(( $# > 0 )) || print_help 'help'
 # first argument must be a shell!
 case "$1" in
 	sh | bash | zsh )


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: print help if module...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/291) |
> | **GitLab MR Number** | [291](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/291) |
> | **Date Originally Opened** | Mon, 12 Aug 2024 |
> | **Date Originally Merged** | Mon, 12 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #312