### PR TITLE
Resolve "modulecmd: eval output of modulecmd.bin only if not empty"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -959,12 +959,15 @@ subcommand_unload() {
 		if [[ "${lmfile}" == '_zzzz_' ]]; then
 			continue
 		fi
+		# yes, module has been loaded
 		local interp
-		is_modulefile modulecmd "${lmfile}" || die_not_a_modulefile "${lmfile}"
+		is_modulefile modulecmd "${lmfile}" || die_not_a_modulefile "${arg}"
 
 	        local output=''
 		output=$("${modulecmd}" "${Shell}" 'unload' "${arg}")
-                eval "$(echo "${output}"|${sed} -e 's/;unalias [^;]*//g')"
+		if [[ -n "${output}" ]]; then
+			eval "$(echo "${output}"|${sed} -e 's/;unalias [^;]*//g')"
+		fi
 		case ${Shell} in
 			sh | bash | zsh )
 				echo "${output}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: eval output of modul...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/296) |
> | **GitLab MR Number** | [296](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/296) |
> | **Date Originally Opened** | Tue, 13 Aug 2024 |
> | **Date Originally Merged** | Tue, 13 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #317