### PR TITLE
Resolve "build-system: pbuild::add_configure_args() shouldn't be marked as deprecated"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -703,8 +703,6 @@ pbuild::prep() {
 #..............................................................................
 #
 pbuild::add_configure_args() {
-	std::info \
-		"Using ${FUNCNAME[0]} is deprecated with YAML module configuration files."
 	CONFIGURE_ARGS+=( "$@" )
 }
 readonly -f pbuild::add_configure_args


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: pbuild::add_confi...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/301) |
> | **GitLab MR Number** | [301](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/301) |
> | **Date Originally Opened** | Wed, 14 Aug 2024 |
> | **Date Originally Merged** | Wed, 14 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #322