### PR TITLE
Resolve "modulecmd: overlays are listed twice"

### DIFF
--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -266,6 +266,8 @@ pm::read_config(){
 		done
 	}
 
+	Overlays=()
+
 	# system config file
 	local -r sys_config_file="${PMODULES_HOME%%/Tools*}/config/Pmodules.yaml"
 	test -r "${sys_config_file}" || \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: overlays are listed ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/302) |
> | **GitLab MR Number** | [302](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/302) |
> | **Date Originally Opened** | Wed, 14 Aug 2024 |
> | **Date Originally Merged** | Wed, 14 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #323