### PR TITLE
Resolve "modulecmd: use of unset variable in sub-cmd unuse"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1993,13 +1993,15 @@ subcommand_unuse() {
 					 "${arg}"
 			fi
 
-                        local var="PMODULES_LOADED_${arg^^}"
-                        if [[ -n "${!var}" ]]; then
-                                std::die 3 "%s %s: %s -- %s" \
-                                         "${CMD}" "${SubCommand}" \
-                                         "cannot remove group due to loaded modules" \
-                                         "${arg}"
-                        fi
+			if [[ -v PMODULES_LOADED_${arg^^} ]]; then 
+				local var="PMODULES_LOADED_${arg^^}"
+				if [[ -n "${!var}" ]]; then
+					std::die 3 "%s %s: %s -- %s" \
+						 "${CMD}" "${SubCommand}" \
+						 "cannot remove group due to loaded modules" \
+						 "${arg}"
+				fi
+			fi
                         std::remove_path UsedGroups "${arg}"
                         local overlay
                         for overlay in "${UsedOverlays[@]}"; do


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: use of unset variabl...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/311) |
> | **GitLab MR Number** | [311](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/311) |
> | **Date Originally Opened** | Wed, 21 Aug 2024 |
> | **Date Originally Merged** | Wed, 21 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #332