### PR TITLE
Resolve "modulecmd: un-using a group is broken"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1962,7 +1962,7 @@ subcommand_unuse() {
 				done
 			done
 
-			# remove additional directories added overlay
+			# remove additional directories added by overlay
 			if [[ -v OverlayInfo[${ol_name}:modulepath] && \
 				      -n "${OverlayInfo[${ol_name}:modulepath]}" ]]; then
 				local -a modulepath=()
@@ -1980,6 +1980,7 @@ subcommand_unuse() {
                         for dir in "${modulepath[@]}"; do
                                 [[ "${dir}" == "${OverlayInfo[${ol_name}:modulefiles_root]}" ]] && \
                                         std::remove_path MODULEPATH "${dir}"
+
                         done
                         export_env UsedOverlays
                         EnvMustBeSaved='yes'
@@ -2007,7 +2008,8 @@ subcommand_unuse() {
                         std::remove_path UsedGroups "${arg}"
                         local overlay
                         for overlay in "${UsedOverlays[@]}"; do
-                                local dir="${overlay}/${arg}/${PMODULES_MODULEFILES_DIR}"
+				local dir="${OverlayInfo[${overlay}:modulefiles_root]}"
+				dir+="/${arg}/${PMODULES_MODULEFILES_DIR}"
 			        std::remove_path MODULEPATH "${dir}"
                         done
 		}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: un-using a group is ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/313) |
> | **GitLab MR Number** | [313](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/313) |
> | **Date Originally Opened** | Wed, 21 Aug 2024 |
> | **Date Originally Merged** | Wed, 21 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #334