### PR TITLE
Resolve "build-system: pbuild::module_is_avail() doesn't work for Lmod"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -203,7 +203,7 @@ pbuild::module_is_avail() {
 	local -- name=''
 	local -- release=''
 	while read -r name release; do
-		if [[ "${name}" == "$1" ]]; then
+		if [[ "${name}" == "$1" || "${name}" == "${1}.lua" ]]; then
 			if (( $# > 1 )); then
 				local -n _result="$2"
 				_result="${release}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: pbuild::module_is...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/314) |
> | **GitLab MR Number** | [314](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/314) |
> | **Date Originally Opened** | Wed, 21 Aug 2024 |
> | **Date Originally Merged** | Wed, 21 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #335