### PR TITLE
Resolve "build-system: don't cleanup modulefiles in the base overlay"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -1399,10 +1399,16 @@ _build_module() {
 	}
 
 	cleanup_modulefiles(){
+		#
+		# FIXME: Can it happen, that we remove module-/config-files which
+		#        we shouldn't remove?
+		#        For now we exclude removing from the overlay 'base' only.
+		#
 		[[ "${is_subpkg}" == 'yes' ]] && return 0
 		local ol=''
 		for ol in "${Overlays[@]}"; do
 			[[ "${ol}" == "${ol_name}" ]] && continue
+			[[ "${ol}" == 'base' ]] && continue
 			local modulefiles_root="${OverlayInfo[${ol}:modulefiles_root]}"
 			local dir="${modulefile_dir/${ol_modulefiles_root}/${modulefiles_root}}"
 			local fname="${dir}/${module_version}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: don't cleanup mod...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/315) |
> | **GitLab MR Number** | [315](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/315) |
> | **Date Originally Opened** | Wed, 21 Aug 2024 |
> | **Date Originally Merged** | Wed, 21 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #336