### PR TITLE
Resolve "modulecmd: use of wrong shell in sub-cmd unload"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1011,7 +1011,7 @@ subcommand_unload() {
 		is_modulefile modulecmd "${lmfile}" || die_not_a_modulefile "${arg}"
 
 	        local output=''
-		output=$("${modulecmd}" "${Shell}" 'unload' "${arg}")
+		output=$("${modulecmd}" 'bash' 'unload' "${arg}")
 		if [[ -n "${output}" ]]; then
 			eval "$(echo "${output}"|${sed} -e 's/;unalias [^;]*//g')"
 		fi


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: use of wrong shell i...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/316) |
> | **GitLab MR Number** | [316](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/316) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #337