### PR TITLE
Merge branch '332-modulecmd-use-of-unset-variable-in-sub-cmd-unuse' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1993,13 +1993,15 @@ subcommand_unuse() {
 					 "${arg}"
 			fi
 
-                        local var="PMODULES_LOADED_${arg^^}"
-                        if [[ -n "${!var}" ]]; then
-                                std::die 3 "%s %s: %s -- %s" \
-                                         "${CMD}" "${SubCommand}" \
-                                         "cannot remove group due to loaded modules" \
-                                         "${arg}"
-                        fi
+			if [[ -v PMODULES_LOADED_${arg^^} ]]; then 
+				local var="PMODULES_LOADED_${arg^^}"
+				if [[ -n "${!var}" ]]; then
+					std::die 3 "%s %s: %s -- %s" \
+						 "${CMD}" "${SubCommand}" \
+						 "cannot remove group due to loaded modules" \
+						 "${arg}"
+				fi
+			fi
                         std::remove_path UsedGroups "${arg}"
                         local overlay
                         for overlay in "${UsedOverlays[@]}"; do


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '332-modulecmd-use-of-unset...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/320) |
> | **GitLab MR Number** | [320](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/320) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: use of unset variable in sub-cmd unuse"

Closes #332

See merge request Pmodules/src!311

(cherry picked from commit 59c116b70bb732f53f0c6381343a89ac94e77628)

fefe313d modulecmd: use of unset variable fixed

Co-authored-by: gsell <achim.gsell@psi.ch>