### PR TITLE
Merge branch...

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1795,11 +1795,13 @@ subcommand_use() {
 				die_illegal_group "${arg}"
 
 			std::append_path UsedGroups "$1"
-                        local ol_name
-                        for ol_name in "${UsedOverlays[@]}"; do
+                        local -- ol_name
+			local -i i=0
+			local -i n="${#UsedOverlays[@]}"
+                        for ((i=n-1; i>=0; i--)); do
+				ol_name="${UsedOverlays[i]}"
                                 local dir="${OverlayInfo[${ol_name}:modulefiles_root]}/$1/${PMODULES_MODULEFILES_DIR}"
                                 [[ -d "${dir}" ]] || continue
-
                                 std::prepend_path MODULEPATH "${dir}"
 				[[ "${OverlayInfo[${ol_name}:type]}" == "${ol_replacing}" ]] && break
                         done


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/321) |
> | **GitLab MR Number** | [321](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/321) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Merge branch '333-modulecmd-module-use-group-adds-directories-of-overlays-in-wrong-order' into 'master'

Resolve "modulecmd: 'module use GROUP' adds directories of overlays in wrong order"

Closes #333

See merge request Pmodules/src!312

(cherry picked from commit ea28d5c0fd9288e861e34263919959b79cd88372)

84f3ab67 modulecmd: fix order of dirs in MODULEPATH

Co-authored-by: gsell <achim.gsell@psi.ch>