### PR TITLE
Merge branch '334-modulecmd-un-using-a-group-is-broken' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1962,7 +1962,7 @@ subcommand_unuse() {
 				done
 			done
 
-			# remove additional directories added overlay
+			# remove additional directories added by overlay
 			if [[ -v OverlayInfo[${ol_name}:modulepath] && \
 				      -n "${OverlayInfo[${ol_name}:modulepath]}" ]]; then
 				local -a modulepath=()
@@ -1980,6 +1980,7 @@ subcommand_unuse() {
                         for dir in "${modulepath[@]}"; do
                                 [[ "${dir}" == "${OverlayInfo[${ol_name}:modulefiles_root]}" ]] && \
                                         std::remove_path MODULEPATH "${dir}"
+
                         done
                         export_env UsedOverlays
                         EnvMustBeSaved='yes'
@@ -2007,7 +2008,8 @@ subcommand_unuse() {
                         std::remove_path UsedGroups "${arg}"
                         local overlay
                         for overlay in "${UsedOverlays[@]}"; do
-                                local dir="${overlay}/${arg}/${PMODULES_MODULEFILES_DIR}"
+				local dir="${OverlayInfo[${overlay}:modulefiles_root]}"
+				dir+="/${arg}/${PMODULES_MODULEFILES_DIR}"
 			        std::remove_path MODULEPATH "${dir}"
                         done
 		}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '334-modulecmd-un-using-a-g...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/322) |
> | **GitLab MR Number** | [322](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/322) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: un-using a group is broken"

Closes #334

See merge request Pmodules/src!313

(cherry picked from commit 850006847302dd994d8f888fff11d45db4bd158d)

d639c08b modulecmd: bugfix in un-using a group

Co-authored-by: gsell <achim.gsell@psi.ch>