### PR TITLE
Merge branch '335-build-system-pbuild-module_is_avail-doesn-t-work-for-lmod' into 'master'

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -203,7 +203,7 @@ pbuild::module_is_avail() {
 	local -- name=''
 	local -- release=''
 	while read -r name release; do
-		if [[ "${name}" == "$1" ]]; then
+		if [[ "${name}" == "$1" || "${name}" == "${1}.lua" ]]; then
 			if (( $# > 1 )); then
 				local -n _result="$2"
 				_result="${release}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '335-build-system-pbuild-mo...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/323) |
> | **GitLab MR Number** | [323](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/323) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: pbuild::module_is_avail() doesn't work for Lmod"

Closes #335

See merge request Pmodules/src!314

(cherry picked from commit 7e61caaa29f44d7dfdc123e97f8ae8b165440dab)

5b817601 build-system: support for Lmod in pbuild::module_is_avail()

Co-authored-by: gsell <achim.gsell@psi.ch>