### PR TITLE
Merge branch '336-build-system-don-t-cleanup-modulefiles-in-the-base-overlay' into 'master'

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -1399,10 +1399,16 @@ _build_module() {
 	}
 
 	cleanup_modulefiles(){
+		#
+		# FIXME: Can it happen, that we remove module-/config-files which
+		#        we shouldn't remove?
+		#        For now we exclude removing from the overlay 'base' only.
+		#
 		[[ "${is_subpkg}" == 'yes' ]] && return 0
 		local ol=''
 		for ol in "${Overlays[@]}"; do
 			[[ "${ol}" == "${ol_name}" ]] && continue
+			[[ "${ol}" == 'base' ]] && continue
 			local modulefiles_root="${OverlayInfo[${ol}:modulefiles_root]}"
 			local dir="${modulefile_dir/${ol_modulefiles_root}/${modulefiles_root}}"
 			local fname="${dir}/${module_version}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '336-build-system-don-t-cle...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/324) |
> | **GitLab MR Number** | [324](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/324) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: don't cleanup modulefiles in the base overlay"

Closes #336

See merge request Pmodules/src!315

(cherry picked from commit 48d5ded1f6182e559681e8d5fa299b984d68d96a)

9b720ba9 build-system: don't cleanup modulefiles in base overlay

Co-authored-by: gsell <achim.gsell@psi.ch>