### PR TITLE
Merge branch '337-modulecmd-use-of-wrong-shell-in-sub-cmd-unload' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1011,7 +1011,7 @@ subcommand_unload() {
 		is_modulefile modulecmd "${lmfile}" || die_not_a_modulefile "${arg}"
 
 	        local output=''
-		output=$("${modulecmd}" "${Shell}" 'unload' "${arg}")
+		output=$("${modulecmd}" 'bash' 'unload' "${arg}")
 		if [[ -n "${output}" ]]; then
 			eval "$(echo "${output}"|${sed} -e 's/;unalias [^;]*//g')"
 		fi


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '337-modulecmd-use-of-wrong...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/325) |
> | **GitLab MR Number** | [325](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/325) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: use of wrong shell in sub-cmd unload"

Closes #337

See merge request Pmodules/src!316

(cherry picked from commit c99e10d1805a6707fa31ac8acebf1fadf7ff530f)

35081f59 modulecmd: bugfix: use of wrong shell in sub-cmd unload

Co-authored-by: gsell <achim.gsell@psi.ch>