### PR TITLE
Merge branch '338-modulecmd-read-dependencies-file-from-same-directory-as-modulefile' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -873,13 +873,17 @@ subcommand_load() {
 		# continue if already loaded
 		[[ ":${LOADEDMODULES}:" == *:${m}:* ]] && continue
 
-		# show info file if exist, load dependencies and the module itself
+		# show info file if exist
 		local prefix=''
 		get_module_prefix prefix "${current_modulefile}"
-                if [[ -n ${prefix} ]]; then
-                        test -r "${prefix}/.info" && cat "$_" 1>&2
-			test -r "${prefix}/.dependencies" && load_dependencies "$_"
-                fi
+		[[ -n ${prefix} && -r "${prefix}/.info" ]] && cat "${prefix}/.info" 1>&2
+
+		# load dependencies
+		local -- deps_file="${current_modulefile%/*}/.deps-${current_modulefile##*/}"
+		if [[ ! -r "${deps_file}" && -n "${prefix}" ]]; then
+			deps_file="${prefix}/.dependencies"
+		fi
+		test -r "${deps_file}" && load_dependencies "$_"
 		local output=''
 		output=$("${modulecmd}" 'bash' "${opts[@]}" 'load' \
                                               "${current_modulefile}" 2> "${TmpFile}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '338-modulecmd-read-depende...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/326) |
> | **GitLab MR Number** | [326](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/326) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: read dependencies file from same directory as modulefile"

Closes #338

See merge request Pmodules/src!317

(cherry picked from commit 25c9525f3f7b1fdaa428db52ce9389c61ada4aec)

cfc844bc modulecmd: read dependencies from file in same directory as modulefile

Co-authored-by: gsell <achim.gsell@psi.ch>