### PR TITLE
Merge branch '339-modulecmd-loading-lmod-files-as-dependencies-of-a-tcl-modulefile' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -658,10 +658,11 @@ USAGE:
 '
 
 subcommand_load() {
-	local relstage='undef'
-	local current_modulefile=''
-	local prefix=''
-	local m=''
+	local -- relstage='undef'
+	local -- current_modulefile=''
+	local -- prefix=''
+	local -- m=''
+	local -A interp
 
 	#......................................................................
 	# output load 'hints'
@@ -873,6 +874,8 @@ subcommand_load() {
 		# continue if already loaded
 		[[ ":${LOADEDMODULES}:" == *:${m}:* ]] && continue
 
+		interp[${current_modulefile}]="${modulecmd}"
+
 		# show info file if exist
 		local prefix=''
 		get_module_prefix prefix "${current_modulefile}"
@@ -884,6 +887,9 @@ subcommand_load() {
 			deps_file="${prefix}/.dependencies"
 		fi
 		test -r "${deps_file}" && load_dependencies "$_"
+
+		# load module
+		modulecmd="${interp[${current_modulefile}]}"
 		local output=''
 		output=$("${modulecmd}" 'bash' "${opts[@]}" 'load' \
                                               "${current_modulefile}" 2> "${TmpFile}")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '339-modulecmd-loading-lmod...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/327) |
> | **GitLab MR Number** | [327](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/327) |
> | **Date Originally Opened** | Fri, 23 Aug 2024 |
> | **Date Originally Merged** | Fri, 23 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: loading Lmod files as dependencies of a Tcl modulefile"

Closes #339

See merge request Pmodules/src!318

(cherry picked from commit af82391ef011036e1a1120e264d5bef9791f0194)

dd14f9d3 modulecmd: loading Lmod modulefiles as deps of Tcl modulefile fixed

Co-authored-by: gsell <achim.gsell@psi.ch>