### PR TITLE
Resolve "build-system: load required overlays to build a module"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -1684,6 +1684,7 @@ _build_module() {
 		"building ..."
 
 	init_module_environment
+	load_overlays
 	load_build_dependencies
 	BUILD_ROOT="${PMODULES_TMPDIR}/${module_name}-${module_version}"
 	SRC_DIR="${BUILD_ROOT}/src"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: load required ove...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/332) |
> | **GitLab MR Number** | [332](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/332) |
> | **Date Originally Opened** | Thu, 29 Aug 2024 |
> | **Date Originally Merged** | Thu, 29 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #341