### PR TITLE
Merge branch '341-build-system-load-required-overlays-to-build-a-module' into 'master'

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -946,12 +946,14 @@ readonly -f pbuild.build_module_legacy
 
 declare -n Config
 declare -a Systems
+declare -a UseOverlays
 pbuild.build_module_yaml(){
 	local -- module_name="$1"
 	local -- module_version="$2"
 	Config="$3"
 	local -- module_relstage="${Config['relstage']}"
 	readarray -t Systems <<< "${Config['systems']}"
+	readarray -t UseOverlays <<< "${Config['use_overlays']}"
 	shift 3
 	_build_module "${module_name}" "${module_version}" "${module_relstage}" "$@"
 }
@@ -981,6 +983,10 @@ _build_module() {
 	#
 	is_loaded() {
 		[[ :${LOADEDMODULES}: =~ :$1: ]]
+	}
+
+	load_overlays(){
+		eval "$( "${modulecmd}" bash use "${Config['use_overlays']}" )"
 	}
 
 	#......................................................................

--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -535,6 +535,7 @@ declare -A Yaml_default_config=(
 	['sub_packages']=''		# !!map
 	['target_cpus']=''		# !!seq of strings
 	['urls']=''			# !!map
+	['use_overlays']=''		# !!seq
 	['variant']=''			# !!str
 )
 
@@ -679,7 +680,7 @@ build_modules_yaml_v1(){
 					pm::get_value "${yaml_input}" value "${key}" '!!seq'
 					cfg[${key,,}]="${value}"
 					;;
-				build_requires|configure_args|docfiles|patch_files|runtime_deps|systems|variant )
+				build_requires|configure_args|docfiles|patch_files|runtime_deps|systems|use_overlays|variant )
 					pm::get_seq "${yaml_input}" value "${key}"
 					cfg[${key,,}]="${value}"
 					;;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '341-build-system-load-requ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/335) |
> | **GitLab MR Number** | [335](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/335) |
> | **Date Originally Opened** | Thu, 29 Aug 2024 |
> | **Date Originally Merged** | Thu, 29 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: load required overlays to build a module"

Closes #341

See merge request Pmodules/src!329

(cherry picked from commit 7ea8fa11ce234adc8180e2140bce8134d2a058c6)

c2f7733c build-system: load required overlays for building a module

Co-authored-by: gsell <achim.gsell@psi.ch>