### PR TITLE
Merge branch '341-build-system-load-required-overlays-to-build-a-module' into 'master'

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -1684,6 +1684,7 @@ _build_module() {
 		"building ..."
 
 	init_module_environment
+	load_overlays
 	load_build_dependencies
 	BUILD_ROOT="${PMODULES_TMPDIR}/${module_name}-${module_version}"
 	SRC_DIR="${BUILD_ROOT}/src"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '341-build-system-load-requ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/336) |
> | **GitLab MR Number** | [336](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/336) |
> | **Date Originally Opened** | Thu, 29 Aug 2024 |
> | **Date Originally Merged** | Thu, 29 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: load required overlays to build a module"

Closes #341

See merge request Pmodules/src!332

(cherry picked from commit 09b4ec55e921000f5256360f66b648b12b62462f)

936bb4e4 build-system: really load the configured overlays

Co-authored-by: gsell <achim.gsell@psi.ch>