### PR TITLE
Merge branch '343-build-system-use-regex-for-the-system-check' into 'master'

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -1235,8 +1235,8 @@ build_modules_yaml_v1(){
 
 			local -- system
 			for system in "${systems[@]}"; do
-				[[ "${opt_system}" == ${system} ]] && return 0
-				[[ "${HOSTNAME}" == ${system} ]] && return 0
+				[[ "${opt_system}" =~ ${system} ]] && return 0
+				[[ "${HOSTNAME}" =~ ${system} ]] && return 0
 			done
 			std::info "Skipping variant '${module_version}', neither OS nor hostname match:"
 			std::info "  This system: ${opt_system}; hostname: ${HOSTNAME}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '343-build-system-use-regex...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/338) |
> | **GitLab MR Number** | [338](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/338) |
> | **Date Originally Opened** | Thu, 29 Aug 2024 |
> | **Date Originally Merged** | Thu, 29 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: use regex for the system  check"

Closes #343

See merge request Pmodules/src!331

(cherry picked from commit 5ccf61065e88f510274141056baa76a15282d18f)

4dcaded2 build-system: change from glob to regex matching for system list

Co-authored-by: gsell <achim.gsell@psi.ch>