### PR TITLE
Merge branch '349-build-system-error-in-reading-variants-in-yaml-config-file' into 'master'

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -1474,13 +1474,13 @@ build_modules_yaml_v1(){
 			used_keys
 
 		# read (default) config of version if set
-		local -A vk_config=()
 		local -- yaml_version_config=''
 		if [[ -v used_keys['config'] ]]; then
-			yaml_version_config=$(${yq} '.config' <<<"${yaml_vk_config}" 2>/dev/null)
+			yaml_version_config=$(${yq} '.config' <<<"${yaml_version_block}" 2>/dev/null)
 			debug "vk input: ${yaml_version_config}"
 		fi
 		# reminder: if YAML input is empty, next line copies defaults to 'vk_config'
+		local -A vk_config=()
 		yml::get_config \
 			yaml_version_config \
 			vk_config \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '349-build-system-error-in-...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/346) |
> | **GitLab MR Number** | [346](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/346) |
> | **Date Originally Opened** | Fri, 30 Aug 2024 |
> | **Date Originally Merged** | Fri, 30 Aug 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: error in reading variants in YAML config file"

Closes #349

See merge request Pmodules/src!345

(cherry picked from commit afe5d0034c176855d2aa0b7aaddbeabcc8eb2380)

e6bae349 build-system: bugfix in reading YAML version config

Co-authored-by: gsell <achim.gsell@psi.ch>