### PR TITLE
Merge branch '350-build-system-handle-empty-variants-blocks' into 'master'

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -818,6 +818,11 @@ build_modules_yaml_v1(){
 
 		local -- type_of_key=''
 		type_of_key=$( ${yq} -e ".variants | type" 2>/dev/null <<<"${yaml_input}")
+		if [[ "${type_of_key}" == '!!null' ]]; then
+			result=''
+			n=0
+			return 0
+                fi
 		if [[ "${type_of_key}" != '!!seq' ]]; then
 			die_invalid_variants_block "${name}" "${version}" \
 						   "${type_of_key}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '350-build-system-handle-em...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/348) |
> | **GitLab MR Number** | [348](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/348) |
> | **Date Originally Opened** | Mon, 2 Sep 2024 |
> | **Date Originally Merged** | Mon, 2 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: handle empty variants blocks"

Closes #350

See merge request Pmodules/src!347

(cherry picked from commit ffbc6292eb32198edac7acd533ecf96ddfead19b)

047d55d8 build-system: bugfix: handle empty variants

Co-authored-by: gsell <achim.gsell@psi.ch>