### PR TITLE
Resolve "build-system: loading overlays fails if more than one overlay has to be loaded"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -986,7 +986,7 @@ _build_module() {
 	}
 
 	load_overlays(){
-		eval "$( "${modulecmd}" bash use "${Config['use_overlays']}" )"
+		eval "$( "${modulecmd}" bash use ${Config['use_overlays']} )"
 	}
 
 	#......................................................................


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: loading overlays ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/349) |
> | **GitLab MR Number** | [349](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/349) |
> | **Date Originally Opened** | Thu, 5 Sep 2024 |
> | **Date Originally Merged** | Thu, 5 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #351