### PR TITLE
Merge branch...

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -986,7 +986,7 @@ _build_module() {
 	}
 
 	load_overlays(){
-		eval "$( "${modulecmd}" bash use "${Config['use_overlays']}" )"
+		eval "$( "${modulecmd}" bash use ${Config['use_overlays']} )"
 	}
 
 	#......................................................................


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/350) |
> | **GitLab MR Number** | [350](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/350) |
> | **Date Originally Opened** | Thu, 5 Sep 2024 |
> | **Date Originally Merged** | Thu, 5 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Merge branch '351-build-system-loading-overlays-fails-if-more-than-one-overlay-has-to-be-loaded' into 'master'

Resolve "build-system: loading overlays fails if more than one overlay has to be loaded"

Closes #351

See merge request Pmodules/src!349

(cherry picked from commit fdc09cdbbc87250484aedddb3783e04e2c555337)

3237a5b1 build-system: bugfix in loading required overlays

Co-authored-by: gsell <achim.gsell@psi.ch>