### PR TITLE
Merge branch '352-psi-openmpi-modules-not-loading-correctly' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -892,6 +892,8 @@ subcommand_load() {
 		fi
 		test -r "${deps_file}" && load_dependencies "$_"
 
+		[[ ":${LOADEDMODULES}:" == *:${m}:* ]] && continue
+
 		# load module
 		modulecmd="${interp[${current_modulefile}]}"
 		local output=''


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '352-psi-openmpi-modules-no...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/352) |
> | **GitLab MR Number** | [352](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/352) |
> | **Date Originally Opened** | Thu, 5 Sep 2024 |
> | **Date Originally Merged** | Thu, 5 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "PSI OpenMPI modules not loading correctly"

Closes #352

See merge request Pmodules/src!351

(cherry picked from commit 340ddd06990cd12fc8f907952bb4048dd1f09ef7)

33f58472 modulecmd: bugfix in loading multiple modules in same call of module

Co-authored-by: gsell <achim.gsell@psi.ch>