### PR TITLE
Merge branch '357-modulecmd-hostname-can-be-the-short-name' into 'master'

### DIFF
--- a/Pmodules/libstd.bash
+++ b/Pmodules/libstd.bash
@@ -51,6 +51,7 @@ file=$(std::def_cmd 'file');		declare -r file
 find=$(std::def_cmd 'find');		declare -r find
 getopt=$(std::def_cmd 'getopt');	declare -r getopt
 grep=$(std::def_cmd 'grep');		declare -r grep
+hostname=$(std::def_cmd 'hostname');	declare -r hostname
 install=$(std::def_cmd 'install');	declare -r install
 logger=$(std::def_cmd 'logger');	declare -r logger
 make=$(std::def_cmd 'make');		declare -r make

--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -64,6 +64,9 @@ TmpFile=$( ${mktemp} /tmp/Pmodules.XXXXXX ) \
 	|| std::die 1 "Oops: unable to create tmp file!"
 declare -r TmpFile
 
+HostName=$(${hostname} -f)
+declare -r HostName
+
 declare -A Subcommands=()
 declare -A Options=()
 declare -A Help=()
@@ -393,7 +396,7 @@ is_available(){
 		[[ -z ${ref_cfg['blocklist']} ]] && return 0
 		local -- s=''
 		for s in ${ref_cfg['blocklist']}; do
-			if [[ "${os_release}" =~ $s ]] || [[ "${HOSTNAME}" =~ $s ]]; then
+			if [[ "${os_release}" =~ $s ]] || [[ "${HostName}" =~ $s ]]; then
 				return 0
 			fi
 		done
@@ -403,7 +406,7 @@ is_available(){
 		[[ -z ${ref_cfg['systems']} ]] && return 0
 		local -- s=''
 		for s in ${ref_cfg['systems']}; do
-			if [[ "${os_release}" =~ $s ]] || [[ "${HOSTNAME}" =~ $s ]]; then
+			if [[ "${os_release}" =~ $s ]] || [[ "${HostName}" =~ $s ]]; then
 				return 0
 			fi
 		done


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '357-modulecmd-hostname-can...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/362) |
> | **GitLab MR Number** | [362](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/362) |
> | **Date Originally Opened** | Tue, 10 Sep 2024 |
> | **Date Originally Merged** | Tue, 10 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: $HOSTNAME can be the short name"

Closes #357

See merge request Pmodules/src!361

(cherry picked from commit ed30c4a73d2342d796771ace6eec3f974114ffcb)

ea7fe278 modulecmd: use 'hostname -f' to get the fqdn not $HOSTNAME

Co-authored-by: gsell <achim.gsell@psi.ch>