### PR TITLE
Merge branch '359-build-system-default-build-function-are-not-defined' into 'master'

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -540,6 +540,10 @@ declare -A Yaml_default_config=(
 	['use_flags']=''		# !!seq
 	['use_overlays']=''		# !!seq
 	['variant']=''			# !!str
+	['target_funcs:prep']='pbuild::pre_prep pbuild::prep pbuild::post_prep'
+	['target_funcs:configure']='pbuild::pre_configure pbuild::configure pbuild::post_configure'
+	['target_funcs:compile']='pbuild::pre_compile pbuild::compile pbuild::post_compile'
+	['target_funcs:install']='pbuild::pre_install pbuild::install pbuild::post_install'
 )
 
 declare -A Yaml_valid_vk_keys=(
@@ -661,9 +665,6 @@ build_modules_yaml_v1(){
 		get_build_functions(){
 			local -n yaml_in="$1"
 			local -a keys=()
-			for key in 'prep' 'configure' 'compile' 'install'; do
-				cfg[target_funcs:${key}]="pbuild::pre_${key} pbuild::${key} pbuild::post_${key}"
-			done
 			readarray -t keys < <( ${yq} -e ".|keys().[]" \
 						     <<<"${yaml_in}" \
 						     2>/dev/null ) || \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '359-build-system-default-b...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/366) |
> | **GitLab MR Number** | [366](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/366) |
> | **Date Originally Opened** | Wed, 11 Sep 2024 |
> | **Date Originally Merged** | Wed, 11 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: default build function are not defined"

Closes #359

See merge request Pmodules/src!365

(cherry picked from commit 877906a73a7c8a3debfad17be2b46794f2b302dd)

d370780e build-system: define build functions in default config

Co-authored-by: gsell <achim.gsell@psi.ch>