### PR TITLE
Merge branch '360-modulecmd-overlayexcludes-matches-everything-if-empty' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1217,7 +1217,7 @@ get_available_modules() {
 		# its sub-directories
 		local mod=''	# module_name/module_version
                 while read -r mod; do
-			[[ "${mod}" =~ ${OverlayExcludes} ]] && continue
+			[[ -n ${OverlayExcludes} && "${mod}" =~ ${OverlayExcludes} ]] && continue
 			local name="${mod%/*}"
 			local add='no'
 			if [[ -n "${ol}" && "${ol}" != 'none' ]]; then


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '360-modulecmd-overlayexclu...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/368) |
> | **GitLab MR Number** | [368](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/368) |
> | **Date Originally Opened** | Wed, 11 Sep 2024 |
> | **Date Originally Merged** | Wed, 11 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: OverlayExcludes matches everything if empty"

Closes #360

See merge request Pmodules/src!367

(cherry picked from commit 99a168996fb8b6749ac13d659841ec7981960114)

a86a0a7c modulecmd: bugfix in handling overlay excludes

Co-authored-by: gsell <achim.gsell@psi.ch>