### PR TITLE
Merge branch '361-build-system-bug-in-loading-used-overlays' into 'master'

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -862,6 +862,7 @@ _build_module() {
 	}
 
 	load_overlays(){
+		[[ -n ${ModuleConfig['use_overlays']} ]] || return 0
 		eval "$( "${modulecmd}" bash use ${ModuleConfig['use_overlays']} )"
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '361-build-system-bug-in-lo...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/370) |
> | **GitLab MR Number** | [370](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/370) |
> | **Date Originally Opened** | Fri, 20 Sep 2024 |
> | **Date Originally Merged** | Fri, 20 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: bug in loading used overlays"

Closes #361

See merge request Pmodules/src!369

(cherry picked from commit afdaa632a07be1060b2e29f03b2afe955ffbb832)

e8f38df1 build-system: bugfix if 'use_overlays' is empty

Co-authored-by: gsell <achim.gsell@psi.ch>