### PR TITLE
Merge branch '363-modulecmd-load-hints-are-not-shown' into 'master'

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -866,15 +866,6 @@ subcommand_load() {
 			modulecmd \
 			"${m}" \
 			"${modulepath[@]}"
-                if [[ -z ${current_modulefile} ]]; then
-			local hints=''
-			get_load_hints hints
-			if [[ -z "${hints}" ]]; then
-				die_module_nexist "${m}"
-			else
-				die_module_unavail "${m}${hints}"
-			fi
-		fi
 
 		[[ ${m} == Pmodules/*  ]] && [[ -n ${LOADEDMODULES} ]] && \
 			die_conflict "${m}"
@@ -1298,12 +1289,13 @@ find_modulefile(){
 
 	}
 	_find_modulefile() {
+		ref_modulefile=''
 		local -- dir=''
 		for dir in "${modulepath[@]}"; do
 			test -d "${dir}" || continue
 			local -i col=$((${#dir} + 2 ))
 			local -- mod=''
-
+			local -a found_modules=()
 			mapfile -t found_modules \
 				< <(find -L "${dir}" \
 					 -type f \
@@ -1363,7 +1355,15 @@ find_modulefile(){
 	else
 		IFS=':' read -r -a modulepath <<< "${MODULEPATH}"
 	fi
-        _find_modulefile || die_module_unavail "${modulename}"
+        if ! _find_modulefile; then
+		local hints=''
+		get_load_hints hints
+		if [[ -z "${hints}" ]]; then
+			die_module_nexist "${modulename}"
+		else
+			die_module_unavail "${modulename}${hints}"
+		fi
+	fi
 
 	is_modulefile modulecmd "${ref_modulefile}" || die_not_a_modulefile "${modulename}"
 	if [[ "${ref_interp}" == "${Lmod_cmd}" ]]; then


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '363-modulecmd-load-hints-a...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/374) |
> | **GitLab MR Number** | [374](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/374) |
> | **Date Originally Opened** | Fri, 20 Sep 2024 |
> | **Date Originally Merged** | Fri, 20 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "modulecmd: load hints are not shown"

Closes #363

See merge request Pmodules/src!373

(cherry picked from commit f36c0f66893d1f403790f6188b3a7d59793640c5)

2c25825a modulecmd: show load hints again

Co-authored-by: gsell <achim.gsell@psi.ch>