### PR TITLE
Resolve "modbuild: if no variant is specified, an uset variable is used"

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -1590,11 +1590,11 @@ build_modules_yaml_v1(){
 
 			if (( num_variants == 0 )); then
 				is_variant_to_be_built \
-					"${module_name}" \
-					"${module_version}" \
+					"${name}" \
+					"${version}" \
 					vk_config || continue
 				build_modules_variant \
-					"${name}" "${v}" \
+					"${name}" "${version}" \
 					vk_config
 			else
 				local -i n=0


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modbuild: if no variant is spec...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/375) |
> | **GitLab MR Number** | [375](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/375) |
> | **Date Originally Opened** | Fri, 20 Sep 2024 |
> | **Date Originally Merged** | Fri, 20 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #364