### PR TITLE
Merge branch '365-build-systems-fix-issues-in-recipes-of-luarocks-and-7z' into 'master'

### DIFF
--- a/recipes/043-luarocks
+++ b/recipes/043-luarocks
@@ -15,7 +15,7 @@ LUA_PREFIX="${PREFIX}/libexec/lua"
 PATH="${LUA_PREFIX}/bin:$PATH" 
 "${SRC_DIR}"/configure \
         --prefix="${LUA_PREFIX}" \
-
+        --with-lua="${LUA_PREFIX}"
 
 #---
 # compile & install

--- a/recipes/120-7z
+++ b/recipes/120-7z
@@ -18,8 +18,9 @@ cd 'CPP/7zip/Bundles/Alone2'
 
 #---
 # compile & install
-make -j -f ../../cmpl_gcc.mak
-cp b/g/7zz "${PREFIX}/${UTILBIN_DIR}/sevenz"
+#make -j -f ../../cmpl_gcc.mak
+make -j 5  -f makefile.gcc
+cp _o/7zz "${PREFIX}/${UTILBIN_DIR}/sevenz"
 
 #---
 # post-install


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '365-build-systems-fix-issu...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/378) |
> | **GitLab MR Number** | [378](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/378) |
> | **Date Originally Opened** | Wed, 25 Sep 2024 |
> | **Date Originally Merged** | Wed, 25 Sep 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-systems: fix issues in recipes of luarocks and 7z"

Closes #365

See merge request Pmodules/src!377

(cherry picked from commit 6a79b5ff5975c3d16bab9ac7a6db68dfb3bab090)

fdfebe1c build-system: bugs in recipes fixed

Co-authored-by: gsell <achim.gsell@psi.ch>