### PR TITLE
Resolve "build-system: bug if systems or used_overlays is not specified in the config file"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -821,15 +821,19 @@ pbuild::install_shared_libs() {
 #
 
 declare -n ModuleConfig
-declare -a Systems
-declare -a UseOverlays
+declare -a Systems=()
+declare -a UseOverlays=()
 pbuild.build_module_yaml(){
 	local -- module_name="$1"
 	local -- module_version="$2"
 	ModuleConfig="$3"
 	local -- module_relstage="${ModuleConfig['relstage']}"
-	readarray -t Systems <<< "${ModuleConfig['systems']}"
-	readarray -t UseOverlays <<< "${ModuleConfig['use_overlays']}"
+	if [[ -n "${ModuleConfig['systems']}" ]]; then
+		readarray -t Systems <<< "${ModuleConfig['systems']}"
+	fi
+	if [[ -n "${ModuleConfig['use_overlays']}" ]]; then
+		readarray -t UseOverlays <<< "${ModuleConfig['use_overlays']}"
+	fi
 	shift 3
 	_build_module "${module_name}" "${module_version}" "${module_relstage}" "$@"
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: bug if systems or...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/382) |
> | **GitLab MR Number** | [382](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/382) |
> | **Date Originally Opened** | Thu, 28 Nov 2024 |
> | **Date Originally Merged** | Thu, 28 Nov 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #369