### PR TITLE
Resolve "build-system: overwrite Pmodules system config file location with env. variable"

### DIFF
--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -271,7 +271,10 @@ pm::read_config(){
 	Overlays=()
 
 	# system config file
-	local -r sys_config_file="${PMODULES_HOME%%/Tools*}/config/Pmodules.yaml"
+	local -- sys_config_file="${PMODULES_HOME%%/Tools*}/config/Pmodules.yaml"
+	if [[ -v PMODULES_CONFIG_FILE && -n "${PMODULES_CONFIG_FILE}" ]]; then
+		sys_config_file="${PMODULES_HOME%%/Tools*}/config/${PMODULES_CONFIG_FILE}"
+	fi
 	test -r "${sys_config_file}" || \
 		std::die 3 \
 			 "%s %s -- %s" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: overwrite Pmodule...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/386) |
> | **GitLab MR Number** | [386](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/386) |
> | **Date Originally Opened** | Thu, 28 Nov 2024 |
> | **Date Originally Merged** | Thu, 28 Nov 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #373