### PR TITLE
build-system: set Pmodules system config file with env. variable

### DIFF
--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -271,7 +271,10 @@ pm::read_config(){
 	Overlays=()
 
 	# system config file
-	local -r sys_config_file="${PMODULES_HOME%%/Tools*}/config/Pmodules.yaml"
+	local -- sys_config_file="${PMODULES_HOME%%/Tools*}/config/Pmodules.yaml"
+	if [[ -v PMODULES_CONFIG_FILE && -n "${PMODULES_CONFIG_FILE}" ]]; then
+		sys_config_file="${PMODULES_HOME%%/Tools*}/config/${PMODULES_CONFIG_FILE}"
+	fi
 	test -r "${sys_config_file}" || \
 		std::die 3 \
 			 "%s %s -- %s" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [build-system: set Pmodules system config...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/395) |
> | **GitLab MR Number** | [395](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/395) |
> | **Date Originally Opened** | Thu, 28 Nov 2024 |
> | **Date Originally Merged** | Thu, 28 Nov 2024 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

(cherry picked from commit 9b996bb1bc385e58a4a791aa990113d5765f8623)

Co-authored-by: Achim Gsell <achim.gsell@psi.ch>