### PR TITLE
modulecmd (#383): required keys added to dict OverlayConfigKeys

### DIFF
--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -80,6 +80,14 @@ declare -A OverlayConfigKeys=(
 	['excludes']=''
 	['type']='n'
 	['modulepath']=''
+	['modulepath_unstable']=''
+	['modulepath_stable']=''
+	['modulepath_deprecated']=''
+	['has_groups']='true'
+	['has_relstages']='true'
+	['default_relstage']='unstable'
+	['has_additional_modulepaths']='false'
+	['conflicts']=''
 )
 
 yml::die_parsing(){


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [modulecmd (#383): required keys added to...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/407) |
> | **GitLab MR Number** | [407](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/407) |
> | **Date Originally Opened** | Mon, 3 Feb 2025 |
> | **Date Originally Merged** | Mon, 3 Feb 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

(cherry picked from commit d0125da316df96fde7eef44084add49b5ff3c73e)

Co-authored-by: Achim Gsell <achim.gsell@psi.ch>