### PR TITLE
Merge branch '386-libstd-bugs-in-std-append_path-and-std-prepend_path' into '1.1.22'

### DIFF
--- a/Pmodules/libstd.bash
+++ b/Pmodules/libstd.bash
@@ -285,6 +285,7 @@ std::append_path () {
 		[[ "${path}" == @(|*:)${dir}@(|:*) ]] && continue
 		dirs+="${dir}:"
 	done
+	[[ -n "${dirs}" ]] || return 0
 
 	# assemble new path
 	dirs="${dirs%:}"		# remove leading ':'
@@ -308,12 +309,13 @@ std::prepend_path () {
 		[[ "${path}" == @(|*:)${dir}@(|:*) ]] && continue
 		dirs+="${dir}:"
 	done
+	[[ -n "${dirs}" ]] || return 0
 
 	# assemble new path
 	dirs="${dirs%:}"		# remove leading ':'
         if [[ -z ${path} ]]; then
                 path="${dirs}"
-        else
+	else
 		path="${dirs}:${path}"
         fi
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '386-libstd-bugs-in-std-app...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/413) |
> | **GitLab MR Number** | [413](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/413) |
> | **Date Originally Opened** | Tue, 4 Feb 2025 |
> | **Date Originally Merged** | Tue, 4 Feb 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "libstd: bugs in std::append_path() and std::prepend_path()"

See merge request Pmodules/src!412

(cherry picked from commit e0841bce3971e490d67684d66ab66b1579a0ef73)

a3ee63cf libstd (#386): bugfixes in std::append_path(), std::prepend_path()

Co-authored-by: gsell <achim.gsell@psi.ch>