### PR TITLE
Resolve "libpmodules: overlay names must be quoted"

### DIFF
--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -207,7 +207,7 @@ pm::read_config(){
 			OverlayInfo[${ol_name}:${key}]="${OverlayConfigKeys[${key}]}"
 		done
 		# get keys in YAML input
-		local -- node=".Overlays.${ol_name}"
+		local -- node=".Overlays.\"${ol_name}\""
 		local -- key=''
 		local -a keys=()
 		yml::get_keys keys yaml_input "${node}"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "libpmodules: overlay names must...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/415) |
> | **GitLab MR Number** | [415](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/415) |
> | **Date Originally Opened** | Wed, 5 Feb 2025 |
> | **Date Originally Merged** | Wed, 5 Feb 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #387