### PR TITLE
Merge branch '391-build-system-change-order-of-checks-to-build-a-module' into 'master'

### DIFF
--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -1335,9 +1335,9 @@ build_modules_yaml_v1(){
 			debug "don't build this variant: ${config['variant']} !=  *:${build_variant}:*"
 			return 0
 		fi
-		check_system     module_config || return 1
 		check_kernel     module_config || return 1
 		check_target_cpu module_config || return 1
+		check_system     module_config || return 1
 		return 0
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Merge branch '391-build-system-change-or...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/422) |
> | **GitLab MR Number** | [422](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/422) |
> | **Date Originally Opened** | Wed, 19 Feb 2025 |
> | **Date Originally Merged** | Wed, 19 Feb 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "build-system: change order of checks to build a module"

Closes #391

See merge request Pmodules/src!421

(cherry picked from commit 3e95734d4e07847de7b7a365cf8039b52dd30c36)

61887f78 build-system: change order of checks to build a module

Co-authored-by: gsell <achim.gsell@psi.ch>