### PR TITLE
Resolve "modulecmd: print correct release stage for Spack modules"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1237,14 +1237,20 @@ get_available_modules() {
 			fi
 			[[ "${add}" == 'no' ]] && continue
 			local -A cfg=()
-			get_module_config cfg "${dir}" "${rel_modulefile}"
+			local -- relstage='stable'
 			if [[ "${OverlayInfo[${ol}:layout]}" == 'Pmodules' ]]; then
+				get_module_config cfg "${dir}" "${rel_modulefile}"
 				is_available cfg "${relstages}" || continue
-				result+=( "${mod}" "${cfg['relstage']}" "${dir}" "${rel_modulefile}" "${ol}" "${group}" )
+				relstage="${cfg['relstage']}"
+			elif [[ "${OverlayInfo[${ol}:layout]}" == 'Spack' ]]; then
+				if [[ ":${UsedReleaseStages}:" =~ :unstable: ]]; then
+					relstage='unstable'
+				fi
 			else
+				get_module_config cfg "${dir}" "${rel_modulefile}"
 				is_available cfg "${ReleaseStages}" || continue
-				result+=( "${mod}" 'stable' "${dir}" "${rel_modulefile}" "${ol}" "${group}" )
 			fi
+			result+=( "${mod}" "${relstage}" "${dir}" "${rel_modulefile}" "${ol}" "${group}" )
                         ref_modules[${mod}]=1
 		done < <(${find} -L "${dir}" \
 				 -not -name ".*" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: print correct releas...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/432) |
> | **GitLab MR Number** | [432](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/432) |
> | **Date Originally Opened** | Thu, 6 Mar 2025 |
> | **Date Originally Merged** | Thu, 6 Mar 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #400