### PR TITLE
Resolve "modulecmd: reverse sort output of avail and search only if pattern is the empty string"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -1241,9 +1241,9 @@ get_available_modules() {
 		fpattern=".*/${pattern}[^/]*/*[^/]+"
 	fi
 	local -- opt_regex='-regex'
-	if [[ "${mode}" != 'load' ]]; then
-		opt_regex='-iregex'
-	fi
+	[[ "${mode}" != 'load' ]] && opt_regex='-iregex'
+	local -- opt_sort='-r'
+	[[ -z ${pattern} ]] && opt_sort=''
 
 	local -- dir=''
 	# loop over all entries in given module path
@@ -1330,7 +1330,7 @@ get_available_modules() {
 				 -regextype posix-basic \) \
 				 \( -type f -o -type l \) \
 				 -printf "%P\n" \
-				 | ${sort} -r --version-sort)
+				 | ${sort} ${opt_sort} --version-sort)
         done
 } # get_available_modules()
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: reverse sort output ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/447) |
> | **GitLab MR Number** | [447](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/447) |
> | **Date Originally Opened** | Wed, 9 Apr 2025 |
> | **Date Originally Merged** | Wed, 9 Apr 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #415