### PR TITLE
Resolve "modulecmd: don't print message if stable module has been loaded"

### DIFF
--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -378,6 +378,7 @@ Thank you for your understanding.
 print_module_load_msg(){
 	local -r relstage="$1"
 	local -- msg=''
+	[[ "${relstage}" == 'stable' ]] && return 0
 	printf -v msg "%s %s: %s -- %s" \
 	       "${CMD}" 'load' \
 	       "${relstage} module has been loaded" \


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: don't print message ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/452) |
> | **GitLab MR Number** | [452](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/452) |
> | **Date Originally Opened** | Wed, 28 May 2025 |
> | **Date Originally Merged** | Wed, 28 May 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #420