### PR TITLE
Resolve "build-system: check for loaded modules doesn't work with Lua modules"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -793,7 +793,9 @@ _build_module() {
 	#	$1	module name
 	#
 	bm::is_loaded() {
-		[[ :${LOADEDMODULES}: =~ :$1: ]]
+		[[ :${LOADEDMODULES}: =~ :$1: ]] && return 0
+		[[ :${LOADEDMODULES}: =~ :$1.lua: ]] && return 0
+		return 1
 	}
 
 	bm::load_overlays(){


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: check for loaded ...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/471) |
> | **GitLab MR Number** | [471](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/471) |
> | **Date Originally Opened** | Mon, 4 Aug 2025 |
> | **Date Originally Merged** | Mon, 4 Aug 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #439