### PR TITLE
Resolve "modulecmd: keeping track of used overlays is broken"

### DIFF
--- a/Pmodules/libmodules.tcl
+++ b/Pmodules/libmodules.tcl
@@ -51,12 +51,13 @@ proc _pmodules_parse_pmodules_env { } {
 				array set ::OverlayInfo $tmp_olinfo
 			}
 		        UsedOverlays {
-			        array set tmp [regsub -all  {[]=[]} $value " "]
-  			        set ::UsedOverlays {}
-				set l [lsort [array names tmp]]
-			        foreach k $l {
-				        lappend ::UsedOverlays $tmp($k)
-			        }
+				# convert a string like
+				# [0]="Alps_A100" [1]="PSI" [2]="Alps" [3]="merlin" [4]="base"
+				# to
+				# Alps_A100 PSI Alps merlin base
+				set tmpstr [regsub -all  {\[[0-9]+\]=} $value ""]
+				set tmpstr [regsub -all  {\"} $tmpstr ""]
+  			        set ::UsedOverlays [split $tmpstr]
 			}
 			UsedGroups {
 				set ::UsedGroups $value
@@ -93,8 +94,9 @@ proc module-addgroup { group } {
 				break
 			}
 		}
-		foreach overlay [lreverse_n $overlays_to_add 1] {
+		foreach overlay [lreverse $overlays_to_add] {
 			debug "overlay=$overlay"
+			debug "modulefiles_root=$::OverlayInfo($overlay:modulefiles_root)"
 			debug "group=$group"
 			debug "::variant=$::variant"
 			set dir [file join \
@@ -102,7 +104,6 @@ proc module-addgroup { group } {
 				     $group \
 				     $::MODULEFILES_DIR \
 				     {*}$::variant]
-		        debug "dir=$dir"
 			if { [file isdirectory $dir] } {
 				debug "prepend $dir to MODULEPATH "
 				prepend-path MODULEPATH $dir

--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -2481,9 +2481,7 @@ subcommand_purge() {
 	#   - used groups
 	local -- saved_groups="${UsedGroups}"
 	#   - used overlays
-	local -- saved_overlays=''
-	printf -v saved_overlays "%s:" "${UsedOverlays[@]}"
-	saved_overlays="${saved_overlays%:}"
+	local -a saved_overlays=( "${UsedOverlays[@]}" )
 	#   - additional directories in MODULEPATH
 	local -- item=''
         local -- group=''
@@ -2499,12 +2497,14 @@ subcommand_purge() {
 	pmodules_setup init
 
 	# - restore
+	# release stages
 	IFS=':' read -r -a items <<<"${saved_relstages}"
 	for item in "${items[@]}"; do
 		subcommand_use "${item}"
 	done
-	IFS=':' read -r -a items <<<"${saved_overlays}"
-	for item in "${items[@]}"; do
+	# overlays
+	for (( i=${#saved_overlays[@]}-1; i>=0; i-- )); do
+		item="${saved_overlays[i]}"
 		[[ -v OverlayInfo[${item}:used] ]] || continue
 		subcommand_use "${item}"
 	done


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "modulecmd: keeping track of use...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/472) |
> | **GitLab MR Number** | [472](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/472) |
> | **Date Originally Opened** | Mon, 4 Aug 2025 |
> | **Date Originally Merged** | Mon, 4 Aug 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #440