### PR TITLE
Resolve "build-system: output message with used overlays"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -800,6 +800,8 @@ _build_module() {
 
 	bm::load_overlays(){
 		[[ -n ${ModuleConfig['use_overlays']} ]] || return 0
+		std::info "%s " \
+			  "using overlays ${ModuleConfig['use_overlays']}"
 		eval "$( "${modulecmd}" bash use ${ModuleConfig['use_overlays']} )"
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: output message wi...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/474) |
> | **GitLab MR Number** | [474](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/474) |
> | **Date Originally Opened** | Mon, 4 Aug 2025 |
> | **Date Originally Merged** | Mon, 4 Aug 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #442