### PR TITLE
Resolve "build-system: build::add_configure_args() was renamed by mistake"

### DIFF
--- a/Pmodules/libpbuild.bash
+++ b/Pmodules/libpbuild.bash
@@ -497,10 +497,10 @@ pbuild.set_configure_args(){
 }
 readonly -f pbuild.set_configure_args
 
-pbuild.add_configure_args(){
+pbuild::add_configure_args(){
 	CONFIGURE_ARGS+=( "$@" )
 }
-readonly -f pbuild.add_configure_args
+readonly -f pbuild::add_configure_args
 
 #..............................................................................
 #


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [Pmodules/Pmodules](https://gitlab.psi.ch/Pmodules/Pmodules) |
> | **GitLab Merge Request** | [Resolve "build-system: build::add_config...](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/481) |
> | **GitLab MR Number** | [481](https://gitlab.psi.ch/Pmodules/Pmodules/merge_requests/481) |
> | **Date Originally Opened** | Thu, 14 Aug 2025 |
> | **Date Originally Merged** | Thu, 14 Aug 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #449