### PR TITLE
bugfix: reading /etc/os-release fixed

### DIFF
--- a/Pmodules/libstd.bash
+++ b/Pmodules/libstd.bash
@@ -367,7 +367,8 @@ std.get_os_release_linux() {
                 ID=$(lsb_release -is)
                 VERSION_ID=$(lsb_release -rs)
         elif [[ -r '/etc/os-release' ]]; then
-	        source /etc/os-release
+		# ignore errors in this file
+	        source /etc/os-release 2>/dev/null
         else
                 std::die 4 "Cannot determin OS release!\n"
         fi

--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -2,8 +2,6 @@
 #
 # shellcheck -x  -e SC1008,SC2239,SC2317,SC2034,SC2128,SC2059,SC2178
 #
-declare -r VERSION='@PMODULES_VERSION@'
-
 unset CDPATH	# unset CDPATH, otherwise 'cd' prints the directoy!
 unset IFS	# use default IFS
 


### PR DESCRIPTION
If the LSB tools are not installed on a Linux system, the OS is determined by sourcing /etc/os-release. In this file a variable VERSION is defined which is already defined and set read-only in modulecmd.