### PR TITLE
build-system: more general default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### build system
 * set CC and CXX if not defined. This was a bug introduced in 2.0.2
+  (#1322)
+* default values for `PMODULES_TMPDIR` and `PMODULES_DISTFILESDIR` are now 
+  more general.
+  (#1325)
 
 ### building Pmodules
 * path to Lua installation fixed in recipe to build luarocks

--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -92,11 +92,11 @@ declare -A DefaultPmodulesConfig=(
 	['default_groups']='Tools:Programming'
 	['defaultreleasestages']='stable'
 	['default_reltages']='stable'
-	['tmpdir']="/opt/psi/var/tmp/${USER}"
-	['tmp_dir']="/opt/psi/var/tmp/${USER}"
-	['distfilesdir']='/opt/psi/var/distfiles'
-	['distfiles_dir']='/opt/psi/var/distfiles'
-	['download_dir']='/opt/psi/var/distfiles'
+	['tmpdir']="/var/tmp/${USER}"
+	['tmp_dir']="/var/tmp/${USER}"
+	['distfilesdir']="${HOME}/.cache/Pmodules/distfiles"
+	['distfiles_dir']="${HOME}/.cache/Pmodules/distfiles"
+	['download_dir']="${HOME}/.cache/Pmodules/distfiles"
 	['overlays']=''
 )
 
@@ -471,6 +471,10 @@ pm::read_config(){
 	fi
 	OverlayInfo[none:type]='n'
 	OverlayInfo[none:layout]='flat'
+
+	PMODULES_DISTFILESDIR=${PMODULES_DISTFILESDIR:-"${DistfilesDir}"}
+	PMODULES_TMPDIR="${PMODULES_TMPDIR:-${TmpDir}"
+	export PMODULES_DISTFILESDIR PMODULES_TMPDIR
 }
 
 # Local Variables:

--- a/Pmodules/libstd.bash
+++ b/Pmodules/libstd.bash
@@ -45,7 +45,7 @@ std::def_cmd2(){
         bin=$(which $1) || std::die 255 "'${name}' not found!"
 
         eval "${name}(){
-                LD_LIBRARY_PATH= LD_PRELOAD= ${bin} \"\$@\"
+                LD_PRELOAD= LD_LIBRARY_PATH= ${bin} \"\$@\"
         }
         declare -g ${name}=${name}
         readonly -f ${name}"
@@ -226,6 +226,7 @@ std::def_cmd2 'mktemp'
 std::def_cmd2 'modulecmd'
 std::def_cmd2 'patch'
 std::def_cmd2 'pwd'
+std::def_cmd2 'readlink'
 std::def_cmd2 'rm'
 std::def_cmd2 'rmdir'
 std::def_cmd2 'sed'

--- a/Pmodules/modbuild.in
+++ b/Pmodules/modbuild.in
@@ -1547,15 +1547,6 @@ pbuild.system "${opt_system}"
 #
 pm::read_config
 
-# :FIXME: should dist files go to
-#         ${pm_root}/var/distfiles
-#         or
-#         ${overlay}/var/distfiles
-#         ?
-PMODULES_DISTFILESDIR=${PMODULES_DISTFILESDIR:-"${PMODULES_HOME%%/Tools*}/var/distfiles"}
-PMODULES_TMPDIR="${PMODULES_TMPDIR:-/var/tmp/${USER}}"
-export PMODULES_DISTFILESDIR PMODULES_TMPDIR
-
 declare -r BUILD_SCRIPT
 declare -r BUILDBLOCK_DIR
 


### PR DESCRIPTION
Default for `PMODULES_TMPDIR` is now `/var/tmp/${USER}` and for `PMODULES_DISTFILESDIR` is now `${HOME}/.cache/Pmodules`