### PR TITLE
libpmodules: substitute env-vars in Pmodules.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   (#1316, #1331)
 
 ### build system
+* Substitute environment variables in TmpDir and DistFilesDir in Pmodules.yaml
+  (#1333)
 * Function to simplify building modules with pip3 added. 
   (#1329)
 * pbuild::install_docfiles() is now obsolete. If called it exists with

--- a/Pmodules/libpmodules.bash.in
+++ b/Pmodules/libpmodules.bash.in
@@ -425,9 +425,11 @@ pm::read_config(){
 					;;
 				tmpdir | tmp_dir )
 					yml::get_value TmpDir yaml_input ".${key}" '!!str'
+					TmpDir="$(envsubst <<<"${TmpDir}")"
 					;;
 				distfilesdir | download_dir )
 					yml::get_value DistfilesDir yaml_input ".${key}" '!!str'
+					DistfilesDir="$(envsubst <<<"${DistfilesDir}")"
 					;;
 				overlays )
 					local -- overlay=''


### PR DESCRIPTION
Subsitute environment variables if used in TmpDir and DistFilesDir in Pmodules.yaml.