### PR TITLE
modulecmd: bugfix in find_overlay()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Issue with Lmod spider command fixed.
   (#1348)
 * Don't allow absolute path names for modules in an overlay.
-  (#1344)
+  (#1344, #1350)
 * It was not possible to load a module with it's absolute path.
   (#1343)
 * Bugfix in unloading modules. Under certain conditions unloading a module

--- a/Pmodules/modulecmd.bash.in
+++ b/Pmodules/modulecmd.bash.in
@@ -550,14 +550,15 @@ find_overlay () {
         local -n ref_group="$2"		# [out] ref.var to return group
 	local -- path="$3"		# [in]  moduledir to check
 
-	path="${path%/"${__MODULEFILES_DIR__}"*}"
+	path="${path%/${__MODULEFILES_DIR__}*}/${__MODULEFILES_DIR__}"
 	local -- ol=''
 	for ol in "${Overlays[@]}"; do
 		local -- modulefiles_root="${OverlayInfo[${ol}:modulefiles_root]}"
-		if [[ "${path}" == ${modulefiles_root}/* ]]; then
+		if [[ "${path}" =~ ${modulefiles_root}/[^/]+/${__MODULEFILES_DIR__} ]]; then
 			ref_ol="${ol}"
 			if [[ "${OverlayInfo[${ref_ol}:layout]}" == 'Pmodules' ]]; then
-				ref_group="${path#"${OverlayInfo[${ol}:modulefiles_root]}"/}"
+				ref_group="${path#${OverlayInfo[${ol}:modulefiles_root]}/}"
+				ref_group="${ref_group%/${__MODULEFILES_DIR__}}"
 			else
 				ref_group='none'
 			fi
@@ -807,7 +808,6 @@ subcommand_load() {
 				output+="module use ${relstage}; "
 			fi
 			local -- group=${line[2]}
-			#echo "group=${group}" 1>&2
 			[[ "${group}" != 'none' ]] || continue
 			if [[ ! ":${UsedGroups}:" == *:${group}:* ]] && \
 				   (( ${GroupDepths[${group}]} == 0 )); then


### PR DESCRIPTION
While fixing #1344 we introduced a new bug in the function find_overlay().